### PR TITLE
Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled : false
+blank_issues_enabled : true
 
 contact_links:
     -   name: "Feature request"


### PR DESCRIPTION
This mandatory issue template seems redundant for advanced users, it would be great to have the option to create blank issues.